### PR TITLE
Allow map as paramater to App.start/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,25 @@ end
 Start your connection to LaunchDarkly on Application start.
 
 ```elixir
-ExLaunchDarkly.App.start(application.fetch_env!(:your_application, :launchdarkly_api_key))
+ExLaunchDarkly.App.start(Application.fetch_env!(:your_application, :launchdarkly_api_key))
 ```
 
 Retrieve a variation.
 
 ```elixir
 ExLaunchDarkly.variation("Some-Flag", ExLaunchDarkly.User.new("SomeUser"), false)
+```
+
+## Testing
+
+You can configure LaunchDarkly to only use a [test data source](https://docs.launchdarkly.com/sdk/features/test-data-sources#erlang):
+```elixir
+ExLaunchDarkly.App.start(
+  "fake-key",
+  %{
+    datasource: :testdata,
+    send_events: false,
+    feature_store: :ldclient_storage_map
+  }
+)
 ```

--- a/lib/ex_launch_darkly/app.ex
+++ b/lib/ex_launch_darkly/app.ex
@@ -3,9 +3,9 @@ defmodule ExLaunchDarkly.App do
   def start(key) when is_binary(key),
     do: key |> String.to_charlist() |> :ldclient.start_instance()
 
-  @spec start(String.t(), atom()) :: :ok | {:error, any(), any()}
-  def start(key, tag) when is_binary(key) and is_atom(tag),
-    do: key |> String.to_charlist() |> :ldclient.start_instance(tag)
+  @spec start(String.t(), atom() | map()) :: :ok | {:error, any(), any()}
+  def start(key, tag_or_map) when is_binary(key) and (is_atom(tag_or_map) or is_map(tag_or_map)),
+    do: key |> String.to_charlist() |> :ldclient.start_instance(tag_or_map)
 
   @spec stop_all() :: :ok
   def stop_all, do: :ldclient.stop_all_instances()


### PR DESCRIPTION
Allow a map as the second parameter for `App.start/2`. This allows using test data sources and [configuring HTTP options](https://github.com/launchdarkly/erlang-server-sdk/releases/tag/1.3.0).

See [start_instance/2](https://hexdocs.pm/launchdarkly_server_sdk/ldclient.html#start_instance-2)