### PR TITLE
refactor app startup, default to include TLS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can configure LaunchDarkly to only use a [test data source](https://docs.lau
 ```elixir
 ExLaunchDarkly.App.start(
   "fake-key",
+  :default,
   %{
     datasource: :testdata,
     send_events: false,

--- a/lib/ex_launch_darkly/app.ex
+++ b/lib/ex_launch_darkly/app.ex
@@ -1,11 +1,19 @@
 defmodule ExLaunchDarkly.App do
-  @spec start(String.t()) :: :ok | {:error, any(), any()}
-  def start(key) when is_binary(key),
-    do: key |> String.to_charlist() |> :ldclient.start_instance()
+  @spec start(String.t(), atom(), map()) :: :ok | {:error, any(), any()}
+  def start(key, tag \\ :default, options \\ %{})
+      when is_binary(key) and is_atom(tag) and is_map(options) do
+    options =
+      Map.merge(
+        %{
+          :http_options => %{
+            :tls_options => :ldclient_config.tls_basic_options()
+          }
+        },
+        options
+      )
 
-  @spec start(String.t(), atom() | map()) :: :ok | {:error, any(), any()}
-  def start(key, tag_or_map) when is_binary(key) and (is_atom(tag_or_map) or is_map(tag_or_map)),
-    do: key |> String.to_charlist() |> :ldclient.start_instance(tag_or_map)
+    key |> String.to_charlist() |> :ldclient.start_instance(tag, options)
+  end
 
   @spec stop_all() :: :ok
   def stop_all, do: :ldclient.stop_all_instances()


### PR DESCRIPTION
Fixes issue in elixir were warnings would get logged every 30seconds.


re: https://github.com/launchdarkly/erlang-server-sdk/issues/68