### PR TITLE
Update actions/cache

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache dialyzer plts
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4
         with:
           path: priv/plts
           key: ${{runner.os}}-${{hashFiles('**/.tool-versions')}}-plts


### PR DESCRIPTION
The actions/cache lib is removing most versions on Feb 1/25  https://github.com/actions/cache/releases/tag/v4.2.0

We're fine with just specifying the major version, as we've never had  any issues with minor version changes.